### PR TITLE
Handle NaNs in polynomial fitting of continuum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,7 @@ dmypy.json
 # Ignore all local history of files
 .history
 .ionide
+
+# Mac 
+.DS_Store
+

--- a/astroNN/apogee/chips.py
+++ b/astroNN/apogee/chips.py
@@ -243,10 +243,11 @@ def continuum(spectra, spectra_err, cont_mask, deg=2):
     for counter, (spectrum, spectrum_err, flux_ivar) in enumerate(
         zip(spectra, spectra_err, flux_ivars)
     ):
+        no_nan_mask = ~np.isnan(spectrum[cont_mask])
         fit = np.polynomial.chebyshev.Chebyshev.fit(
-            x=np.arange(spectrum.shape[0])[cont_mask],
-            y=spectrum[cont_mask],
-            w=flux_ivar[cont_mask],
+            x=np.arange(spectrum.shape[0])[cont_mask][no_nan_mask],
+            y=spectrum[cont_mask][no_nan_mask],
+            w=flux_ivar[cont_mask][no_nan_mask],
             deg=deg,
         )
         spectra[counter] = spectrum / fit(pix_element)


### PR DESCRIPTION
Using `apogee_continuum()` with dr = 17 led to NaN values appearing in the continuum spectra during the polynomial fit. This led to the polynomial fit, in `continuum()`, failing. This did not happen for dr = 14 since with dr = 14 there were no NaNs in the continuum spectra. I changed `continuum()` so it now filters NaNs before conducting a fit. From initial checks, the outputs of `continuum()` remained the same for dr = 14 before and after this change.

Now, `apogee_continuum()` works with dr = 17. 